### PR TITLE
[BUGFIX] blackbox_decrypt_all_files fails on chmod

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,7 +8,7 @@ ENV GNUPGHOME /gnupg
 ENV BLACKBOX_REPOBASE /repo
 WORKDIR $BLACKBOX_REPOBASE
 
-RUN apk add --no-cache make git gnupg1 bash
+RUN apk add --no-cache make git gnupg1 bash coreutils
 RUN git clone https://github.com/StackExchange/blackbox.git /usr/blackbox \
  && cd /usr/blackbox \
  && make manual-install


### PR DESCRIPTION
- PB: blackbox_decrypt_all_files call chmod with --reference option, which is missing on base package.
- FIX: add GNU tools which provides the GNU chmod with --reference option

and BTW thx for this docker image !
