### PR TITLE
blackbox_shred_all_files fails

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,7 +8,7 @@ ENV GNUPGHOME /gnupg
 ENV BLACKBOX_REPOBASE /repo
 WORKDIR $BLACKBOX_REPOBASE
 
-RUN apk add --no-cache make git gnupg1 bash coreutils
+RUN apk add --no-cache make git gnupg1 bash coreutils findutils
 RUN git clone https://github.com/StackExchange/blackbox.git /usr/blackbox \
  && cd /usr/blackbox \
  && make manual-install


### PR DESCRIPTION
Just found a new missing requirement.
- PB: blackbox_shred_all_files calls xargs with parameter -P which is not available by default.
- FIX: install findutils
